### PR TITLE
Support for logtarget="SYSLOG"

### DIFF
--- a/fail2banIPlist.sh
+++ b/fail2banIPlist.sh
@@ -121,7 +121,7 @@ case "$command" in
 			prefix="sudo "
 		fi
 
-		chains=`$prefix iptables -n -L | grep -iE '^Chain fail2ban-' | sed -r 's/.*(fail2ban-[^ ]+).*/\1/g'`
+		chains=`$prefix iptables -n -L | grep -iE '^Chain fail2ban-' | sed -r 's/.*(fail2ban-[^ ]+).*/\1/'`
 		for chain in $chains; do
 			jail=`echo "$chain" | sed -r s/fail2ban-//`
 			ban=`$prefix iptables -n -L "$chain" | grep -iE '^(REJECT|DROP)' | awk -v jail="$jail" '{ print jail" "$4 }'`
@@ -141,7 +141,7 @@ case "$command" in
 		fi
 
 		zgrep -h " Ban " "$logfolder/fail2ban.log"* | \
-		sed -r 's/([^,]+).*[^\[]+\[([^]]+)\] Ban (.+)/\1 \2 \3/g' | \
+		sed -r 's/([^,]+).*[^\[]+\[([^]]+)\] Ban (.+)/\1 \2 \3/' | \
 		sort -t " " -k 1.1,1.4n"$order" -k 1.6,1.7n"$order" -k 1.9,1.10n"$order" -k 2.1,2.2n"$order" -k 2.4,2.5n"$order" -k 2.7,2.8n"$order" | \
 		(echo "DATE TIME JAIL IP"; cat) | \
 		column -t
@@ -159,7 +159,7 @@ case "$command" in
 		fi
 
 		zgrep -h " Ban " "$logfolder/fail2ban.log"* | \
-		sed -r 's/([^,]+).*[^\[]+\[([^]]+)\] Ban (.+)/\1 \2 \3/g' | \
+		sed -r 's/([^,]+).*[^\[]+\[([^]]+)\] Ban (.+)/\1 \2 \3/' | \
 		sort -t " " -k 1.1,1.4nr -k 1.6,1.7nr -k 1.9,1.10nr -k 2.1,2.2nr -k 2.4,2.5nr -k 2.7,2.8nr | \
 		head -n $lines | \
 		sort -t " " -k 1.1,1.4n"$order" -k 1.6,1.7n"$order" -k 1.9,1.10n"$order" -k 2.1,2.2n"$order" -k 2.4,2.5n"$order" -k 2.7,2.8n"$order" | \

--- a/fail2banIPlist.sh
+++ b/fail2banIPlist.sh
@@ -12,7 +12,7 @@ Options:
   -c command (MANDATORY, see below)
   -h displays this help
   -n number of lines to display (only for the 'latest' command)
-  -o order of the results (only for the 'all', 'latest' and 'offences' command)
+  -o order 'asc' or 'desc' of the results (only for the 'all', 'latest' and 'offences' command)
   -t threshold of number of offences for an IP to be listed (only for the 'offences' command)
   -v displays version of this script
 

--- a/fail2banIPlist.sh
+++ b/fail2banIPlist.sh
@@ -150,8 +150,10 @@ case "$command" in
 	latest)
 		if [ "$order" == 'asc' ]; then
 			order=''
+			STRIP="tail"
 		else
 			order='r'
+			STRIP="head"
 		fi
 
 		if [ "$lines" == "" ] || [ "$lines" -lt 0 ]; then
@@ -160,9 +162,8 @@ case "$command" in
 
 		zgrep -h " Ban " "$logfolder/fail2ban.log"* | \
 		sed -r 's/([^,]+).*[^\[]+\[([^]]+)\] Ban (.+)/\1 \2 \3/' | \
-		sort -t " " -k 1.1,1.4nr -k 1.6,1.7nr -k 1.9,1.10nr -k 2.1,2.2nr -k 2.4,2.5nr -k 2.7,2.8nr | \
-		head -n $lines | \
 		sort -t " " -k 1.1,1.4n"$order" -k 1.6,1.7n"$order" -k 1.9,1.10n"$order" -k 2.1,2.2n"$order" -k 2.4,2.5n"$order" -k 2.7,2.8n"$order" | \
+		$STRIP -n $lines | \
 		(echo "DATE TIME JAIL IP"; cat) | \
 		column -t
 		;;

--- a/fail2banIPlist.sh
+++ b/fail2banIPlist.sh
@@ -140,7 +140,7 @@ case "$command" in
 			order=''
 		fi
 
-		zgrep " Ban " "$logfolder/fail2ban.log"* | \
+		zgrep -h " Ban " "$logfolder/fail2ban.log"* | \
 		sed -r 's/[^:]+:([^,]+)[^\[]+\[([^]]+)\] Ban (.+)/\1 \2 \3/g' | \
 		sort -t " " -k 1.1,1.4n"$order" -k 1.6,1.7n"$order" -k 1.9,1.10n"$order" -k 2.1,2.2n"$order" -k 2.4,2.5n"$order" -k 2.7,2.8n"$order" | \
 		(echo "DATE TIME JAIL IP"; cat) | \
@@ -158,7 +158,7 @@ case "$command" in
 			lines=10
 		fi
 
-		zgrep " Ban " "$logfolder/fail2ban.log"* | \
+		zgrep -h " Ban " "$logfolder/fail2ban.log"* | \
 		sed -r 's/[^:]+:([^,]+)[^\[]+\[([^]]+)\] Ban (.+)/\1 \2 \3/g' | \
 		sort -t " " -k 1.1,1.4nr -k 1.6,1.7nr -k 1.9,1.10nr -k 2.1,2.2nr -k 2.4,2.5nr -k 2.7,2.8nr | \
 		head -n $lines | \
@@ -175,7 +175,7 @@ case "$command" in
 		fi
 
 		if [ "$threshold" != "" ]; then
-			zgrep " Ban " "$logfolder/fail2ban.log"* | \
+			zgrep -h " Ban " "$logfolder/fail2ban.log"* | \
 			awk '{ print $7 }' | \
 			sort | \
 			uniq -c | \
@@ -184,7 +184,7 @@ case "$command" in
 			(echo "IP OFFENCES"; awk '{ print $2" "$1 }') | \
 			column -t
 		else
-			zgrep " Ban " "$logfolder/fail2ban.log"* | \
+			zgrep -h " Ban " "$logfolder/fail2ban.log"* | \
 			awk '{ print $7 }' | \
 			sort | \
 			uniq -c | \
@@ -195,7 +195,7 @@ case "$command" in
 		;;
 
 	medalists)
-		zgrep " Ban " "$logfolder/fail2ban.log"* | \
+		zgrep -h " Ban " "$logfolder/fail2ban.log"* | \
 		awk '{ print $7 }' | \
 		sort | \
 		uniq -c | \

--- a/fail2banIPlist.sh
+++ b/fail2banIPlist.sh
@@ -141,7 +141,7 @@ case "$command" in
 		fi
 
 		zgrep -h " Ban " "$logfolder/fail2ban.log"* | \
-		sed -r 's/[^:]+:([^,]+)[^\[]+\[([^]]+)\] Ban (.+)/\1 \2 \3/g' | \
+		sed -r 's/([^,]+).*[^\[]+\[([^]]+)\] Ban (.+)/\1 \2 \3/g' | \
 		sort -t " " -k 1.1,1.4n"$order" -k 1.6,1.7n"$order" -k 1.9,1.10n"$order" -k 2.1,2.2n"$order" -k 2.4,2.5n"$order" -k 2.7,2.8n"$order" | \
 		(echo "DATE TIME JAIL IP"; cat) | \
 		column -t
@@ -159,7 +159,7 @@ case "$command" in
 		fi
 
 		zgrep -h " Ban " "$logfolder/fail2ban.log"* | \
-		sed -r 's/[^:]+:([^,]+)[^\[]+\[([^]]+)\] Ban (.+)/\1 \2 \3/g' | \
+		sed -r 's/([^,]+).*[^\[]+\[([^]]+)\] Ban (.+)/\1 \2 \3/g' | \
 		sort -t " " -k 1.1,1.4nr -k 1.6,1.7nr -k 1.9,1.10nr -k 2.1,2.2nr -k 2.4,2.5nr -k 2.7,2.8nr | \
 		head -n $lines | \
 		sort -t " " -k 1.1,1.4n"$order" -k 1.6,1.7n"$order" -k 1.9,1.10n"$order" -k 2.1,2.2n"$order" -k 2.4,2.5n"$order" -k 2.7,2.8n"$order" | \

--- a/fail2banIPlist.sh
+++ b/fail2banIPlist.sh
@@ -3,7 +3,7 @@
 # TODO
 # * Country of the medalists
 
-version='1.1.0'
+version='1.2.0'
 self=`basename $0`
 logfolder=/var/log
 usage="Usage: $self [options]

--- a/fail2banIPlist.sh
+++ b/fail2banIPlist.sh
@@ -142,7 +142,7 @@ case "$command" in
 
 		zgrep -h " Ban " "$logfolder/fail2ban.log"* | \
 		sed -r 's/([^,]+).*[^\[]+\[([^]]+)\] Ban (.+)/\1 \2 \3/' | \
-		sort -t " " -k 1.1,1.4n"$order" -k 1.6,1.7n"$order" -k 1.9,1.10n"$order" -k 2.1,2.2n"$order" -k 2.4,2.5n"$order" -k 2.7,2.8n"$order" | \
+		sort -t " " -k 1$order -k 2$order | \
 		(echo "DATE TIME JAIL IP"; cat) | \
 		column -t
 		;;
@@ -162,7 +162,7 @@ case "$command" in
 
 		zgrep -h " Ban " "$logfolder/fail2ban.log"* | \
 		sed -r 's/([^,]+).*[^\[]+\[([^]]+)\] Ban (.+)/\1 \2 \3/' | \
-		sort -t " " -k 1.1,1.4n"$order" -k 1.6,1.7n"$order" -k 1.9,1.10n"$order" -k 2.1,2.2n"$order" -k 2.4,2.5n"$order" -k 2.7,2.8n"$order" | \
+		sort -t " " -k 1$order -k 2$order | \
 		$STRIP -n $lines | \
 		(echo "DATE TIME JAIL IP"; cat) | \
 		column -t


### PR DESCRIPTION
Support for same functions, if fail2ban is configured with logtarget="SYSLOG", where the logs are in /var/log/syslog and in other format.
